### PR TITLE
Use SPDX license identifier in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description": "Library for using browsermob-proxy with PHP projects",
   "keywords": ["testing"],
   "homepage": "https://github.com/chartjes/PHPBrowserMobProxy/",
-  "license": "Apache 2",
+  "license": "Apache-2.0",
   "authors": [
       {
       "name": "Chris Hartjes",


### PR DESCRIPTION
Composer uses standard identifiers for license names, which allows
tools to analyze and make use of that information.

See also:
- http://getcomposer.org/doc/04-schema.md#license
